### PR TITLE
Overhaul `init`.

### DIFF
--- a/app/src/main/assets/init
+++ b/app/src/main/assets/init
@@ -1,1 +1,29 @@
-S=android.settings;echo 设置存储 Setup storage;termux-setup-storage;DATA=package:com.termux;echo -n 设置悬浮窗权限 Setup draw over apps \(请按回车 Press Enter\);read i;am start -a $S.action.MANAGE_OVERLAY_PERMISSION -d $DATA>/dev/null;echo -n 设置禁用电池优化 Setup ignore battery optimizations \(请按回车 Press Enter\);read i;am start -a $S.IGNORE_BATTERY_OPTIMIZATION_SETTINGS>/dev/null;echo -n 设置关联启动与后台弹出权限 Setup Startup \& Background pop-ups permissions \(请按回车 Press Enter\);read i;am start -a $S.APPLICATION_DETAILS_SETTINGS -d $DATA>/dev/null;echo 设置allow-external-app Setup allow-external-app;fl=/data/data/com.termux/files/home/.termux/termux.properties;if [ -f $fl ];then awk '/^#/{print;next }/^\s*allow-external-apps/{gsub(/allow-external-apps.*/,"allow-external-apps=true");found=1}{print $0}END{if(!found)print "allow-external-apps=true"}' $fl>$TMPDIR/a.tmp && mv $TMPDIR/a.tmp $fl;else mkdir -p `dirname $fl`;echo 'allow-external-apps=true'>$fl;fi;echo 安装Clang Install Clang;pkg i clang -y;apt autoremove --purge;apt clean;echo ok
+#!/system/bin/sh
+SETTINGS_PACKAGE_RDNS=android.settings
+echo '中文： 设置存储, English: Setup storage'
+termux-setup-storage
+TERMUX_DATA=package:com.termux
+echo -n '中文： 设置悬浮窗权限 (请按回车), English: Setup "draw over apps" (Press "Enter")'
+read i
+am start -a $SETTINGS_PACKAGE_RDNS.action.MANAGE_OVERLAY_PERMISSION -d $TERMUX_DATA > /dev/null
+echo -n '中文： 设置禁用电池优化 (请按回车), English: Setup "ignore battery optimizations" (Press "Enter")'
+read i
+am start -a $SETTINGS_PACKAGE_RDNS.IGNORE_BATTERY_OPTIMIZATION_SETTINGS > /dev/null
+echo -n '中文： 设置关联启动与后台弹出权限 (请按回车), English: Setup "Startup & Background pop-ups permissions" (Press "Enter")'
+read i
+am start -a $SETTINGS_PACKAGE_RDNS.APPLICATION_DETAILS_SETTINGS -d $TERMUX_DATA > /dev/null
+echo '中文： 设置allow-external-app, English: Setup "allow-external-app"'
+termux_properties_path=/data/data/com.termux/files/home/.termux/termux.properties
+if [ -f $termux_properties_path ]
+then awk '/^#/{print
+next }/^\s*allow-external-apps/{gsub(/allow-external-apps.*/,"allow-external-apps=true")
+found=1}{print $0}END{if(!found)print "allow-external-apps=true"}' $termux_properties_path > "$TMPDIR"/a.tmp && \
+	mv "$TMPDIR"/a.tmp $termux_properties_path
+else mkdir -p $(dirname $termux_properties_path)
+echo 'allow-external-apps=true' > $termux_properties_path
+fi
+echo '中文： 安装CLang, English: Install CLang'
+pkg i clang -y
+apt autoremove --purge
+apt clean
+echo ok


### PR DESCRIPTION
Per [`issues/23#issuecomment-2848563465`](https://github.com/RainbowC0/TermuC/issues/23#issuecomment-2848563465:~:text=differentiating%20between%20when%20the%20Chinese,International%20English%20using%20YAML%20syntax.):

<blockquote>

Differentiating between when the Chinese loanwords and English begin when there's merely a space character to separarate them isn't trivial in a single line. Consequently, I:

1. ...ran your script through [`koalaman/shellcheck`](https://github.com/koalaman/shellcheck/releases/tag/v0.10.0) at [`shellcheck.net`](https://www.shellcheck.net/). This:

   1. ...replaced backticks with modern `$()` syntax.

   1. ...advised that I add a shebang, for which I added `#!/system/bin/sh`.

1. ...ran an find of `;` to replace with `\n`.

1. ...replaced the single or double-letter variable names with comprehensible ones.

1. ...separated the Simplified Chinese from the International English using YAML syntax.

</blockquote>